### PR TITLE
Move to newer version of rke2

### DIFF
--- a/docs/AWS_Setup.md
+++ b/docs/AWS_Setup.md
@@ -129,10 +129,3 @@ The above command will delete the Private AI stack, including the VM itself.
 [rke2]: https://www.rancher.com/products/secure-kubernetes-distribution
 [sle-micro]: https://www.suse.com/products/micro/
 
-# Known Issues
-1. Known issue with newer version of gpu-operator and rke2 1.31:
-
-After the gpu-operator deployed, you will see some pods stuck. This issue is reported in https://github.com/NVIDIA/gpu-operator/issues/991
-The gpu-operator modifies the containerd configuration and restarts containerd while other pods are created.
-When the containerd goes down, while interacting with the kubeapi server, you will see an error like this net/http: TLS handshake timeout - error from a previous attempt: http2: server sent GOAWAY and closed the connection; LastStreamID=1, ErrCode=NO_ERROR, debug=""
-The workaround is to delete the stuck gpu-operator pods to force a restart.

--- a/extra_vars.yml.aws.example
+++ b/extra_vars.yml.aws.example
@@ -171,17 +171,9 @@ aws_image_ami_account_number: amazon
 #
 # Rancher version to use
 #
-# Default to 2.9.2
+# Default to 2.11.1
 #
-#rancher_version: 2.9.2
-
-#
-# RKE2 channel to install a specific version of RKE2 server.
-# See see https://update.rke2.io/v1-release/channels for a complete list
-#
-# By default, the "v1.30.5+rke2r1" version will be used.
-#
-#rke2_channel_version: v1.30.5+rke2r1
+#rancher_version: 2.11.1
 
 #####################################################
 # DO NOT modify there, period! These are immutable. #
@@ -252,4 +244,4 @@ cluster:
   num_worker_nodes_gpu: 0
   num_worker_nodes_nongpu: 0
   token: "ai-rke2token"
-  version: "v1.30.5+rke2r1" #RKE2 channel version. see https://update.rke2.io/v1-release/channels for a complete list
+  version: "v1.32.4+rke2r1" #RKE2 channel version. see https://update.rke2.io/v1-release/channels for a complete list

--- a/extra_vars.yml.local.example
+++ b/extra_vars.yml.local.example
@@ -124,17 +124,9 @@ time_slicing_replicas: 4
 #
 # Rancher version to use
 #
-# Default to 2.9.2
+# Default to 2.11.1
 #
-#rancher_version: 2.9.2
-
-#
-# RKE2 channel to install a specific version of RKE2 server.
-# See see https://update.rke2.io/v1-release/channels for a complete list
-#
-# By default, the "v1.30.5+rke2r1" version will be used.
-#
-#rke2_channel_version: v1.30.5+rke2r1
+#rancher_version: 2.11.1
 
 #
 # VM user plain text password (not hash)

--- a/playbooks/setup_private_ai_stack.yml
+++ b/playbooks/setup_private_ai_stack.yml
@@ -132,6 +132,12 @@
         rke2endpoint: "{{ hostvars['localhost']['kubeapi_fqdn'] }}"
         service_name: "rke2-server"
 
+    #https://github.com/NVIDIA/gpu-operator/issues/992#issuecomment-2796578769
+    - name: Update PATH
+      become: true
+      shell: |
+        echo PATH=$PATH:/usr/local/nvidia/toolkit >> /etc/default/rke2-server
+
 - hosts: cp_others
   tasks:
     - name: Deploy RKE2
@@ -141,6 +147,12 @@
         rke2endpoint: "{{ hostvars['localhost']['kubeapi_fqdn'] }}"
         service_name: "rke2-server"
 
+    #https://github.com/NVIDIA/gpu-operator/issues/992#issuecomment-2796578769
+    - name: Update PATH
+      become: true
+      shell: |
+        echo PATH=$PATH:/usr/local/nvidia/toolkit >> /etc/default/rke2-server
+
 - hosts: agents
   tasks:
     - name: Deploy RKE2
@@ -149,6 +161,12 @@
       vars:
         rke2endpoint: "{{ hostvars['localhost']['kubeapi_fqdn'] }}"
         service_name: "rke2-agent"
+
+      #https://github.com/NVIDIA/gpu-operator/issues/992#issuecomment-2796578769
+    - name: Update PATH
+      become: true
+      shell: |
+        echo PATH=$PATH:/usr/local/nvidia/toolkit >> /etc/default/rke2-agent
 
 - hosts: cp_master
   tasks:

--- a/roles/nvidia-gpu-operator/tasks/main.yml
+++ b/roles/nvidia-gpu-operator/tasks/main.yml
@@ -56,14 +56,8 @@
         enabled: "{{ enable_nfd }}"
       toolkit:
         env:
-          - name: CONTAINERD_CONFIG
-            value: /var/lib/rancher/rke2/agent/etc/containerd/config.toml.tmpl
           - name: CONTAINERD_SOCKET
             value: /run/k3s/containerd/containerd.sock
-          - name: CONTAINERD_RUNTIME_CLASS
-            value: nvidia
-          - name: CONTAINERD_SET_AS_DEFAULT
-            value: "true"
   when: not enable_time_slicing
 
 # see https://docs.nvidia.com/datacenter/cloud-native/gpu-operator/latest/gpu-sharing.html#time-slicing-gpus-in-kubernetes
@@ -81,16 +75,59 @@
         enabled: "{{ enable_nfd }}"
       toolkit:
         env:
-          - name: CONTAINERD_CONFIG
-            value: /var/lib/rancher/rke2/agent/etc/containerd/config.toml.tmpl
           - name: CONTAINERD_SOCKET
             value: /run/k3s/containerd/containerd.sock
-          - name: CONTAINERD_RUNTIME_CLASS
-            value: nvidia
-          - name: CONTAINERD_SET_AS_DEFAULT
-            value: "true"
       devicePlugin:
         config:
           name: time-slicing-config-all
           default: any
   when: enable_time_slicing
+
+- name: Wait for NVIDIA GPU Operator Deploy to be rolled out
+  shell: >
+    kubectl -n {{ gpu_operator_namespace }} rollout status deploy/{{ item }}
+  register: gpu_operator_deploy_rollout_result
+  retries: 10
+  delay: 30
+  with_items:
+  - "{{ gpu_operator_release }}"
+  until: "'successfully rolled out' in gpu_operator_deploy_rollout_result.stdout"
+
+- name: Wait for NVIDIA GPU Operator NFD Deploy to be rolled out
+  shell: >
+    kubectl -n {{ gpu_operator_namespace }} rollout status deploy/{{ item }}
+  register: gpu_operator_deploy_rollout_result
+  retries: 10
+  delay: 30
+  with_items:
+  - "{{ gpu_operator_release }}-node-feature-discovery-gc"
+  - "{{ gpu_operator_release }}-node-feature-discovery-master"
+  until: "'successfully rolled out' in gpu_operator_deploy_rollout_result.stdout"
+  when: enable_nfd
+
+# https://docs.rke2.io/advanced#deploy-nvidia-operator
+# WARNING: The NVIDIA operator restarts containerd with a hangup call which restarts RKE2
+- name: Pause for cluster to stabilize
+  ansible.builtin.pause:
+    minutes: 4
+
+- name: Wait for port 9345
+  wait_for:
+    port: 9345
+    delay: 10
+    timeout: 120
+
+- name: Wait for NVIDIA GPU Operator NFD DaemonSet to be rolled out
+  shell: >
+    kubectl -n {{ gpu_operator_namespace }} rollout status daemonset/{{ item }}
+  register: gpu_operator_ds_rollout_result
+  retries: 10
+  delay: 60
+  with_items:
+  - "{{ gpu_operator_release }}-node-feature-discovery-worker"
+  - "gpu-feature-discovery"
+  - "nvidia-container-toolkit-daemonset"
+  - "nvidia-device-plugin-daemonset"
+  until: "'successfully rolled out' in gpu_operator_ds_rollout_result.stdout"
+  when: enable_nfd
+

--- a/roles/rancher/defaults/main.yml
+++ b/roles/rancher/defaults/main.yml
@@ -3,7 +3,7 @@
 use_rancher_prime: true
 
 # Rancher version to use
-rancher_version: 2.9.2
+rancher_version: 2.11.1
 
 rancher_helm_repo_url: "{{ 'https://charts.rancher.com/server-charts/prime' if use_rancher_prime else 'https://releases.rancher.com/server-charts/stable' }}"
 rancher_helm_repo_name: "{{ 'rancher-prime' if use_rancher_prime else 'rancher-stable' }}"

--- a/roles/rancher/tasks/main.yml
+++ b/roles/rancher/tasks/main.yml
@@ -25,10 +25,13 @@
 
 - name: Wait for Rancher to be rolled out
   shell: >
-    kubectl -n {{ rancher_namespace }} rollout status deploy/{{ rancher_release }}
+    kubectl -n {{ rancher_namespace }} rollout status deploy/{{ item }}
   register: rancher_rollout_result
-  retries: 5
-  delay: 10
+  retries: 10
+  delay: 30
+  with_items:
+    - "{{ rancher_release }}"
+    - "{{ rancher_release }}-webhook"
   until: "'successfully rolled out' in rancher_rollout_result.stdout"
 
 # per https://github.com/rancher/local-path-provisioner

--- a/roles/rke2/tasks/main.yml
+++ b/roles/rke2/tasks/main.yml
@@ -90,7 +90,7 @@
 
 - name: Install RKE2
   shell: >
-    sudo INSTALL_RKE2_CHANNEL={{ cluster.version | default('v1.30.5+rke2r1') }} /tmp/rke2_installer.sh
+    sudo INSTALL_RKE2_CHANNEL={{ cluster.version | default('v1.32.4+rke2r1') }} /tmp/rke2_installer.sh
 
 - name: Enable and start service
   become: true

--- a/roles/vm/terraform/terraform.template
+++ b/roles/vm/terraform/terraform.template
@@ -26,5 +26,5 @@ cluster = {
     num_worker_nodes_gpu = 0
     num_worker_nodes_nongpu = 0
     token = "ai-rke2token"
-    version = "v1.30.5+rke2r1"
+    version = "v1.32.4+rke2r1"
 }

--- a/roles/vm/terraform/variables.tf
+++ b/roles/vm/terraform/variables.tf
@@ -44,6 +44,6 @@ variable "cluster" {
     num_worker_nodes_gpu = 0
     num_worker_nodes_nongpu = 0
     token = "ai-rke2token"
-    version = "v1.30.5+rke2r1"
+    version = "v1.32.4+rke2r1"
   }
 }


### PR DESCRIPTION
Earlier we had issue with latest version
of gpu-operator failing to deploy
against newer version of rke2 with the
gpu-operator daemonsets failing.

This change allows us to move to newer
versions of rke2 and gpu-operator by
following the steps specified in rke2 doc
https://docs.rke2.io/advanced#operator-installation