### PR TITLE
Default to openSUSE Leap Micro for local env

### DIFF
--- a/roles/vm/defaults/main.yml
+++ b/roles/vm/defaults/main.yml
@@ -15,7 +15,7 @@ cloud_provider: local
 ##################################################################
 
 # URL to download the cloud image
-cloud_image_download_url: https://download.suse.de/download/ibs/SUSE/Products/SL-Micro/6.0/x86_64/SL-Micro.x86_64-6.0-Default-qcow-GM.qcow2 
+cloud_image_download_url: https://download.opensuse.org/distribution/leap-micro/6.1/appliances/openSUSE-Leap-Micro.x86_64-Default-qcow.qcow2
 #cloud_image_checksum_url: "sha256:{{ cloud_image_download_url }}.sha256"
 
 # Image name for identification purposes


### PR DESCRIPTION
So that user doesn't have to go through SCC to download the commercial image.