### PR TITLE
exclude registration for opensuse leap distro

### DIFF
--- a/playbooks/setup_private_ai_stack.yml
+++ b/playbooks/setup_private_ai_stack.yml
@@ -92,7 +92,7 @@
       become: true
       shell: |
         transactional-update register --url {{ registration_server | default("https://scc.suse.com") }} --email {{ registration_email }} --regcode "{{ registration_code }}"
-      when: (cluster is defined and cluster.image_distro == "sle-micro") or cluster is not defined
+      when: (cluster is defined and cluster.image_distro == "sle-micro") or (cluster is not defined and '"openSUSE" not in cloud_image_download_url')
       register: register_result
       failed_when: "'Error' in register_result.stdout"
 

--- a/roles/suse-private-ai/templates/open-webui-values.yaml.j2
+++ b/roles/suse-private-ai/templates/open-webui-values.yaml.j2
@@ -2,11 +2,11 @@ global:
   imagePullSecrets:
   - {{ appco_secret }}
 {% if "dp.apps.rancher.io" in openwebui_helm_repo %}
-image:
-  registry: dp.apps.rancher.io
-  repository: containers/open-webui
-  tag: {{ openwebui_image_version }}
-  pullPolicy: IfNotPresent
+#image:
+#  registry: dp.apps.rancher.io
+#  repository: containers/open-webui
+#  tag: {{ openwebui_image_version }}
+#  pullPolicy: IfNotPresent
 {% else %}
 image:
   repository: ghcr.io/open-webui/open-webui
@@ -29,11 +29,11 @@ ollama:
   enabled: true
 {% endif %}
 {% if "dp.apps.rancher.io" in ollama_helm_repo %}
-  image:
-    registry: dp.apps.rancher.io
-    repository: containers/ollama
-    tag: {{ ollama_image_version }}
-    pullPolicy: IfNotPresent
+  #image:
+  #  registry: dp.apps.rancher.io
+  #  repository: containers/ollama
+  #  tag: {{ ollama_image_version }}
+  #  pullPolicy: IfNotPresent
 {% else %}
   image:
     repository: ollama/ollama

--- a/roles/vm/defaults/main.yml
+++ b/roles/vm/defaults/main.yml
@@ -19,7 +19,7 @@ cloud_image_download_url: https://download.opensuse.org/distribution/leap-micro/
 #cloud_image_checksum_url: "sha256:{{ cloud_image_download_url }}.sha256"
 
 # Image name for identification purposes
-cloud_image_os_name: SL-Micro-6.0.0
+cloud_image_os_name: SL-Micro-6.1
 
 # OS variant for libvirt optimization. See virt-install --os-variant
 vm_os_variant: sle15


### PR DESCRIPTION
Also comment out the image sections for the overrides to avoid deploying older versions of the containers with newer charts.