### PR TITLE
fix: add double quotes to kubectl download url

### DIFF
--- a/roles/kubernetes-tools/tasks/install_kubernetes_toolchain.yml
+++ b/roles/kubernetes-tools/tasks/install_kubernetes_toolchain.yml
@@ -22,8 +22,8 @@
 - name: Install kubectl
   become: true
   shell: |
-    curl -LO https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/{{ image_arch }}/kubectl
-    curl -LO https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/{{ image_arch }}/kubectl.sha256
+    curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/{{ image_arch }}/kubectl"
+    curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/{{ image_arch }}/kubectl.sha256"
     echo "$(cat kubectl.sha256)  kubectl" | sha256sum --check
     install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl
   args:


### PR DESCRIPTION
The unquoted URL in the `curl` command was throwing the error "URL rejected: Malformed input to a URL function" which was breaking the whole task script.