### PR TITLE
fix: missing enable_external_dns variable when it's not defined on extra_vars

### DIFF
--- a/roles/suse-observability/templates/ingress_otel_values.yaml.j2
+++ b/roles/suse-observability/templates/ingress_otel_values.yaml.j2
@@ -4,7 +4,7 @@ opentelemetry-collector:
     annotations:
       nginx.ingress.kubernetes.io/proxy-body-size: "50m"
       nginx.ingress.kubernetes.io/backend-protocol: GRPC
-{% if cloud_provider is defined and cloud_provider == "aws" and enable_external_dns %}
+{% if cloud_provider is defined and cloud_provider == "aws" and enable_external_dns | default(false) %}
       external-dns.alpha.kubernetes.io/target: {{ suse_observability_target }}
       external-dns.alpha.kubernetes.io/ttl: "60"
 {% endif %}

--- a/roles/suse-observability/templates/ingress_values.yaml.j2
+++ b/roles/suse-observability/templates/ingress_values.yaml.j2
@@ -4,7 +4,7 @@ ingress:
   annotations:
     nginx.ingress.kubernetes.io/proxy-body-size: "50m"
     nginx.ingress.kubernetes.io/ssl-redirect: "true"
-{% if cloud_provider is defined and cloud_provider == "aws" and enable_external_dns %}
+{% if cloud_provider is defined and cloud_provider == "aws" and enable_external_dns | default(false) %}
     external-dns.alpha.kubernetes.io/target: {{ suse_observability_target }}
     external-dns.alpha.kubernetes.io/ttl: "60"
 {% endif %}


### PR DESCRIPTION
Problem description: When the variable 'enable_external_dns is not defined on extra_vars, the deployment complains about this variable being not defined.

