### PR TITLE
Automatically configure OI filter for observability

### DIFF
--- a/extra_vars.yml.aws.example
+++ b/extra_vars.yml.aws.example
@@ -244,7 +244,7 @@ suse_observability_license: <your SUSE Observability license>
 #
 # Install openwebui pipelines
 #
-pipelines_enabled: false
+pipelines_enabled: true
 
 #
 # RKE2 Management cluster

--- a/extra_vars.yml.local.example
+++ b/extra_vars.yml.local.example
@@ -229,4 +229,4 @@ suse_observability_license: <your SUSE Observability license>
 
 # Install openwebui pipelines
 #
-pipelines_enabled: false
+pipelines_enabled: true

--- a/roles/suse-private-ai/defaults/main.yml
+++ b/roles/suse-private-ai/defaults/main.yml
@@ -50,7 +50,8 @@ ollama_helm_version: 1.16.0
 ollama_image_version: 0.6.8
 ollama_release_name: ollama
 
-pipelines_enabled: false
+pipelines_enabled: true
+pipelines_default: "https://raw.githubusercontent.com/SUSE/suse-ai-observability-extension/refs/heads/main/integrations/oi-filter/suse_ai_filter.py"
 
 # helm repo to use for vllm charts
 vllm_chart_name: vllm-stack

--- a/roles/suse-private-ai/templates/open-webui-values.yaml.j2
+++ b/roles/suse-private-ai/templates/open-webui-values.yaml.j2
@@ -68,6 +68,11 @@ pipelines:
   enabled: {{ pipelines_enabled }}
   persistence:
     storageClass: {{ storage_class }}
+{% if enable_suse_observability %}
+  extraEnvVars:
+  - name: PIPELINES_URLS
+    value: {{ pipelines_default }}
+{% endif %}
 ingress:
   enabled: true
   class: ""
@@ -87,6 +92,8 @@ extraEnvVars:
   value: "pending"
 - name: ENABLE_SIGNUP
   value: "true"
+- name: OPENAI_API_KEY
+  value: "0p3n-w3bu!"
 - name: WEBUI_NAME
   value: "SUSE AI"
 - name: GLOBAL_LOG_LEVEL


### PR DESCRIPTION
When SUSE Observability is enabled, we should add the observability filter to OI so we can have telemetry data readily available.

No further alterations; just waiting for the latest version of the pipeline container.