### PR TITLE
vllm deployment updates

### DIFF
--- a/extra_vars.yml.aws.example
+++ b/extra_vars.yml.aws.example
@@ -211,6 +211,15 @@ time_slicing_replicas: 4
 #  gpu_operator_chart_version: 24.6.0
 
 #
+# Flag to control vllm deployment.
+# Set this flag to true to deploy vllm.
+# The cluster should have at least one GPU node
+# and enable_gpu_operator to be true.
+# Recommended configuration: Multiple GPU nodes in cluster. For more details please see the cluster: secton.
+#
+enable_vllm_deployment: false
+
+#
 # Flag to control milvus deployment. When false, it won't be deployed. Default is true
 #
 enable_milvus: true

--- a/extra_vars.yml.local.example
+++ b/extra_vars.yml.local.example
@@ -202,6 +202,14 @@ private_ai_vm_libvirt_network_params: "--network network={{ private_ai_vm_networ
 #host_device: <device to passthrough>
 
 #
+# Flag to control vllm deployment.
+# Set this flag to true to deploy vllm.
+# The cluster should have at least one GPU node
+# and enable_gpu_operator to be true.
+#
+enable_vllm_deployment: false
+
+#
 # Flag to control milvus deployment. When false, it won't be deployed. Default is true
 #
 enable_milvus: true
@@ -210,7 +218,6 @@ enable_milvus: true
 # Flag to control milvus deployment mode. When false, standalone deployment. When true, cluster deployment
 #
 enable_milvus_cluster_deployment: true
-
 
 #
 # Flag to control minio deployment mode. When false, distributed deployment. When true, standalone deployment

--- a/roles/suse-private-ai/defaults/main.yml
+++ b/roles/suse-private-ai/defaults/main.yml
@@ -52,11 +52,16 @@ ollama_release_name: ollama
 
 pipelines_enabled: false
 
+openwebui_vllm_openai_enabled: true
+openwebui_vllm_openai_key: "dummy"
+
+enable_vllm_deployment: false
+
 # helm repo to use for vllm charts
 vllm_chart_name: vllm-stack
 #vllm_helm_repo: oci://dp.apps.rancher.io/charts/{{ vllm_chart_name }}
 vllm_helm_repo: https://vllm-project.github.io/production-stack/
-vllm_helm_version: 0.1.5
+vllm_helm_version: 0.1.6
 vllm_core_image_version: 0.9.1
 vllm_cache_image_version: 0.3.2
 vllm_release_name: vllm

--- a/roles/suse-private-ai/files/template_chatml.jinja
+++ b/roles/suse-private-ai/files/template_chatml.jinja
@@ -1,0 +1,2 @@
+{% for message in messages %}{{'<|im_start|>' + message['role'] + '\n' + message['content']}}{% if (loop.last and add_generation_prompt) or not loop.last %}{{ '<|im_end|>' + '\n'}}{% endif %}{% endfor %}
+{% if add_generation_prompt and messages[-1]['role'] != 'assistant' %}{{ '<|im_start|>assistant\n' }}{% endif %}

--- a/roles/suse-private-ai/tasks/main.yml
+++ b/roles/suse-private-ai/tasks/main.yml
@@ -15,7 +15,7 @@
 
 - name: vllm deploy
   include_tasks: vllm.yml
-  when: enable_gpu_operator | default(false)
+  when: enable_gpu_operator | default(false) and enable_vllm_deployment | default(false)
 
 - name: open-webui deploy
   include_tasks: open-webui.yml

--- a/roles/suse-private-ai/tasks/vllm.yml
+++ b/roles/suse-private-ai/tasks/vllm.yml
@@ -1,3 +1,17 @@
+- name: Copy chat template jinja template
+  copy:
+    src: files/template_chatml.jinja
+    dest: ~/template_chatml.jinja
+
+- name: Get GPU node count in the cluster to tweak vllm_config memory utilization
+  shell: |
+    kubectl get nodes -l "nvidia.com/gpu.present=true" -o jsonpath="{.items[*].metadata.name}" --no-headers | wc -w
+  register: get_gnodes
+
+- name: Set GPU present node count in cluster
+  set_fact:
+    gpu_present_node_count: get_gnodes.stdout
+
 - name: Copy vllm-values.yaml
   template:
     src: vllm-values.yaml.j2
@@ -18,7 +32,7 @@
   when: not deploy_rancher_only | default(False) | bool
 
 - name: Wait for vllm to be successfully rolled out
-  shell: >
+  shell: |
     kubectl -n {{ suse_private_ai_namespace }} rollout status deploy/{{ item }}
   register: rollout_result
   retries: 30

--- a/roles/suse-private-ai/templates/open-webui-values.yaml.j2
+++ b/roles/suse-private-ai/templates/open-webui-values.yaml.j2
@@ -101,3 +101,9 @@ extraEnvVars:
 - name: MILVUS_URI
   value: http://milvus.{{ suse_private_ai_namespace}}.svc.cluster.local:19530
 {% endif %}
+{% if enable_vllm_deployment | default(false) and enable_gpu_operator | default(false) and openwebui_vllm_openai_enabled %}
+- name: OPENAI_API_BASE_URL
+  value: "http://vllm-router-service.{{ suse_private_ai_namespace}}.svc.cluster.local:80/v1"
+- name: OPENAI_API_KEY
+  value: "{{ openwebui_vllm_openai_key }}"
+{% endif %}

--- a/roles/suse-private-ai/templates/vllm-values.yaml.j2
+++ b/roles/suse-private-ai/templates/vllm-values.yaml.j2
@@ -15,13 +15,20 @@ servingEngineSpec:
     imagePullPolicy: "IfNotPresent"
 {% endif %}
     modelURL: "{{ vllm_model_url }}"
+    chatTemplate: "chat.jinja2"
+    # chat template for opt-125m
+    chatTemplateConfigMap: "{{ lookup('file', 'files/template_chatml.jinja') }}"
     replicaCount: 1
-    requestCPU: 2
+{% if gpu_present_node_count | int < 2 %}
+    requestCPU: 1
     requestMemory: "8Gi"
     requestGPU: 1
     vllmConfig:
-      # share the timesliced GPU with Ollama
-      extraArgs: ["--disable-log-requests", "--enforce-eager", "--gpu-memory-utilization", "0.5"]
+      extraArgs: ["--disable-log-requests", "--enforce-eager", "--gpu-memory-utilization", "0.8"]
+{% else %}
+    requestCPU: 2
+    requestMemory: "16Gi"
+{% endif %}
 routerSpec:
 {% if "dp.apps.rancher.io" in  vllm_helm_repo  %}
   registry: dp.apps.rancher.io


### PR DESCRIPTION
1. Integrate open-webui with vllm
2. Use the latest upstream chart 0.1.6
3. Introduce a flag to enable deployment of vllm. Default is disabled.
4. Provide chatTemplate configuration needed for the facebook/opt-125m model
5. Additional vllmConfig to better utilize gpu memory based on how many nodes have GPU.