### PR TITLE
upgrade versions of gpu-operator, rke2, local-path provisioner

### DIFF
--- a/docs/AWS_Setup.md
+++ b/docs/AWS_Setup.md
@@ -66,7 +66,7 @@ suse_ai_cluster:
   num_worker_nodes_gpu: 0
   num_worker_nodes_nongpu: 0
   token: "suse-ai-rke2token"
-  version: "v1.32.4+rke2r1" #RKE2 channel version. see https://update.rke2.io/v1-release/channels for a complete list
+  version: "v1.34.4+rke2r1" #RKE2 channel version. see https://update.rke2.io/v1-release/channels for a complete list
 ```
 
 ```
@@ -83,7 +83,7 @@ suse_observability_cluster:
   num_cp_nodes: 1
   num_worker_nodes: 1
   token: "suse-observability-rke2token"
-  version: "v1.32.4+rke2r1" #RKE2 channel version. see https://update.rke2.io/v1-release/channels for a complete list
+  version: "v1.34.4+rke2r1" #RKE2 channel version. see https://update.rke2.io/v1-release/channels for a complete list
 ```
 
 We support deploying using SLE-Micro and SLES based EC2 instances.

--- a/extra_vars.yml.aws.example
+++ b/extra_vars.yml.aws.example
@@ -216,9 +216,9 @@ enable_time_slicing: true
 time_slicing_replicas: 4
 
 #
-# set the NVIDIA GPU Operator chart version defaults to 24.6.0
+# set the NVIDIA GPU Operator chart version defaults to 25.10.1
 #
-#  gpu_operator_chart_version: 24.6.0
+#  gpu_operator_chart_version: 25.10.1
 
 #
 # Flag to control vllm deployment.
@@ -292,5 +292,5 @@ cluster:
   num_worker_nodes_gpu: 0
   num_worker_nodes_nongpu: 0
   token: "mgmt-rke2token"
-  version: "v1.32.4+rke2r1" #RKE2 channel version. see https://update.rke2.io/v1-release/channels for a complete list
+  version: "v1.34.4+rke2r1" #RKE2 channel version. see https://update.rke2.io/v1-release/channels for a complete list
 

--- a/playbooks/define_nodes_mgmt_cluster.yml
+++ b/playbooks/define_nodes_mgmt_cluster.yml
@@ -86,12 +86,13 @@
 
         # Nvidia
         nvidia:
-          driver_install: {{ (true if not (use_nvidia_driver_installer | default(false)) else false) | lower }}
+          driver_install: {{ (false if (use_nvidia_driver_installer | default(false)) else (enable_nvidia_driver_pkg_install | default(true))) | lower }}
           gpu_operator_deploy: {{ (false if (use_nvidia_driver_installer | default(false)) else (enable_gpu_operator | default(false))) | lower }}
+          gpu_operator_version: {{  gpu_operator_chart_version | default('25.10.1')}}
 
         # RKE2
         rke2:
-          version:  {{ cluster.version | default('v1.32.4+rke2r1') }}
+          version:  {{ cluster.version | default('v1.34.4+rke2r1') }}
           token: {{ cluster.token | default('mgmt-rke2token') }}
           lb_address: "{{ hostvars['localhost']['kubeapi_fqdn'] }}"
 

--- a/playbooks/define_nodes_suse_ai_cluster.yml
+++ b/playbooks/define_nodes_suse_ai_cluster.yml
@@ -88,12 +88,13 @@
 
         # Nvidia
         nvidia:
-          driver_install: {{ (true if not (use_nvidia_driver_installer | default(false)) else false) | lower }}
+          driver_install: {{ (false if (use_nvidia_driver_installer | default(false)) else (enable_nvidia_driver_pkg_install | default(true))) | lower }}
           gpu_operator_deploy: {{ (false if (use_nvidia_driver_installer | default(false)) else (enable_gpu_operator | default(false))) | lower }}
+          gpu_operator_version: {{  gpu_operator_chart_version | default('25.10.1')}}
 
         # RKE2
         rke2:
-          version:  {{ suse_ai_cluster.version  | default('v1.32.4+rke2r1') }}
+          version:  {{ suse_ai_cluster.version  | default('v1.34.4+rke2r1') }}
           token: {{ suse_ai_cluster.token | default('suse-ai-rke2token') }}
           lb_address: "{{ hostvars['localhost']['suse_ai_kubeapi_fqdn'] }}"
 

--- a/playbooks/define_nodes_suse_observability_cluster.yml
+++ b/playbooks/define_nodes_suse_observability_cluster.yml
@@ -72,10 +72,11 @@
         nvidia:
           driver_install: false
           gpu_operator_deploy: false
+          gpu_operator_version: {{  gpu_operator_chart_version | default('25.10.1')}}
 
         # RKE2
         rke2:
-          version:  {{ suse_observability_cluster.version | default('v1.32.4+rke2r1') }}
+          version:  {{ suse_observability_cluster.version | default('v1.34.4+rke2r1') }}
           token: {{ suse_observability_cluster.token | default('suse-observability-rke2token') }}
           lb_address: "{{ hostvars['localhost']['suse_observability_kubeapi_fqdn'] }}"
 

--- a/roles/local-path/defaults/main.yml
+++ b/roles/local-path/defaults/main.yml
@@ -1,1 +1,1 @@
-local_path_provisioner_version: v0.0.28
+local_path_provisioner_version: v0.0.34

--- a/roles/suse-private-ai/templates/ollama-values.yaml.j2
+++ b/roles/suse-private-ai/templates/ollama-values.yaml.j2
@@ -27,6 +27,3 @@ persistentVolume:
 extraEnv:
   - name: OLLAMA_DEBUG
     value: "1"
-{% if enable_gpu_operator %}
-runtimeClassName: "nvidia"
-{% endif %}

--- a/roles/suse-private-ai/templates/open-webui-values.yaml.j2
+++ b/roles/suse-private-ai/templates/open-webui-values.yaml.j2
@@ -62,7 +62,6 @@ ollama:
       enabled: true
       type: 'nvidia'
       number: 1
-  runtimeClassName: "nvidia"
 {% endif %}
 pipelines:
   enabled: {{ pipelines_enabled }}

--- a/roles/vm/terraform/variables.tf
+++ b/roles/vm/terraform/variables.tf
@@ -45,7 +45,7 @@ variable "cluster" {
     num_worker_nodes_gpu = 0
     num_worker_nodes_nongpu = 0
     token = "ai-rke2token"
-    version = "v1.32.4+rke2r1"
+    version = "v1.34.4+rke2r1"
   }
 }
 


### PR DESCRIPTION
The newer version of the gpu-operator does not require the runtimeClassName to be set. The change also removes this. Also include passing in gpu_operator_chart_version to the suse-ai-node-ansible playbooks.