### PR TITLE
Add gpu operator config to support new metrics from SO extension

### DIFF
--- a/roles/nvidia-gpu-operator/defaults/main.yml
+++ b/roles/nvidia-gpu-operator/defaults/main.yml
@@ -1,0 +1,6 @@
+---
+gpu_operator_namespace: gpu-operator
+gpu_operator_configmap_name: gpu-operator-values
+gpu_operator_dcgm_configmap_name: dcgm-custom-counters
+gpu_operator_custom_counters_file: "{{ role_path }}/files/custom-counters.csv"
+enable_virtual_gpus: true

--- a/roles/nvidia-gpu-operator/files/custom-counters.csv
+++ b/roles/nvidia-gpu-operator/files/custom-counters.csv
@@ -1,0 +1,53 @@
+# Format
+# If line starts with a '#' it is considered a comment
+# DCGM FIELD, Prometheus metric type, help message
+
+# Clocks
+DCGM_FI_DEV_SM_CLOCK, gauge, SM clock frequency (in MHz).
+DCGM_FI_DEV_MEM_CLOCK, gauge, Memory clock frequency (in MHz).
+
+# Temperature
+DCGM_FI_DEV_MEMORY_TEMP, gauge, Memory temperature (in C).
+DCGM_FI_DEV_GPU_TEMP, gauge, GPU temperature (in C).
+
+# Power
+DCGM_FI_DEV_POWER_USAGE, gauge, Power draw (in W).
+DCGM_FI_DEV_TOTAL_ENERGY_CONSUMPTION, counter, Total energy consumption since boot (in mJ).
+
+# PCIE
+DCGM_FI_DEV_PCIE_REPLAY_COUNTER, counter, Total number of PCIe retries.
+
+# Utilization (the sample period varies depending on the product)
+DCGM_FI_DEV_GPU_UTIL, gauge, GPU utilization (in %).
+DCGM_FI_DEV_MEM_COPY_UTIL, gauge, Memory utilization (in %).
+DCGM_FI_DEV_ENC_UTIL, gauge, Encoder utilization (in %).
+DCGM_FI_DEV_DEC_UTIL, gauge, Decoder utilization (in %).
+
+# Errors and violations
+DCGM_FI_DEV_XID_ERRORS, gauge, Value of the last XID error encountered.
+
+# Memory usage
+DCGM_FI_DEV_FB_FREE, gauge, Framebuffer memory free (in MiB).
+DCGM_FI_DEV_FB_USED, gauge, Framebuffer memory used (in MiB).
+DCGM_FI_DEV_FB_RESERVED, gauge, Framebuffer memory reserved (in MiB).
+
+# NVLink
+DCGM_FI_DEV_NVLINK_BANDWIDTH_TOTAL, counter, Total number of NVLink bandwidth counters for all lanes.
+
+# VGPU License status
+DCGM_FI_DEV_VGPU_LICENSE_STATUS, gauge, vGPU License status
+
+# Remapped rows
+DCGM_FI_DEV_UNCORRECTABLE_REMAPPED_ROWS, counter, Number of remapped rows for uncorrectable errors
+DCGM_FI_DEV_CORRECTABLE_REMAPPED_ROWS, counter, Number of remapped rows for correctable errors
+DCGM_FI_DEV_ROW_REMAP_FAILURE, gauge, Whether remapping of rows has failed
+
+# Static configuration information. These appear as labels on the other metrics
+DCGM_FI_DRIVER_VERSION, label, Driver Version
+
+# Datacenter Profiling (DCP) metrics
+DCGM_FI_PROF_GR_ENGINE_ACTIVE, gauge, Ratio of time the graphics engine is active.
+DCGM_FI_PROF_PIPE_TENSOR_ACTIVE, gauge, Ratio of cycles the tensor (HMMA) pipe is active.
+DCGM_FI_PROF_DRAM_ACTIVE, gauge, Ratio of cycles the device memory interface is active sending or receiving data.
+DCGM_FI_PROF_PCIE_TX_BYTES, gauge, The rate of data transmitted over the PCIe bus - including both protocol headers and data payloads - in bytes per second.
+DCGM_FI_PROF_PCIE_RX_BYTES, gauge, The rate of data received over the PCIe bus - including both protocol headers and data payloads - in bytes per second.

--- a/roles/nvidia-gpu-operator/tasks/main.yml
+++ b/roles/nvidia-gpu-operator/tasks/main.yml
@@ -1,0 +1,33 @@
+---
+- name: Ensure gpu-operator namespace exists
+  kubernetes.core.k8s:
+    state: present
+    definition:
+      apiVersion: v1
+      kind: Namespace
+      metadata:
+        name: "{{ gpu_operator_namespace }}"
+
+- name: Create DCGM custom counters ConfigMap
+  shell: |
+    kubectl create configmap {{ gpu_operator_dcgm_configmap_name }} \
+      --from-file=custom-counters.csv={{ gpu_operator_custom_counters_file }} \
+      -n {{ gpu_operator_namespace }} \
+      --dry-run=client -o yaml | kubectl apply -f -
+
+- name: Template gpu-operator Helm values
+  template:
+    src: gpu-operator-values.yaml.j2
+    dest: "/tmp/gpu-operator-values.yaml"
+
+- name: Create gpu-operator-values ConfigMap
+  shell: |
+    kubectl create configmap {{ gpu_operator_configmap_name }} \
+      --from-file=gpu-operator-values.yaml=/tmp/gpu-operator-values.yaml \
+      -n {{ gpu_operator_namespace }} \
+      --dry-run=client -o yaml | kubectl apply -f -
+
+- name: Clean up temp file
+  file:
+    path: "/tmp/gpu-operator-values.yaml"
+    state: absent

--- a/roles/nvidia-gpu-operator/templates/gpu-operator-values.yaml.j2
+++ b/roles/nvidia-gpu-operator/templates/gpu-operator-values.yaml.j2
@@ -1,0 +1,18 @@
+dcgm-exporter:
+{% if enable_virtual_gpus | default(true) %}
+  env:
+    - name: KUBERNETES_VIRTUAL_GPUS
+      value: "true"
+{% endif %}
+  extraConfigMapVolumes:
+    - name: dcgm-counters-volume
+      configMap:
+        name: {{ gpu_operator_dcgm_configmap_name }}
+  extraEnv:
+    - name: DCGM_EXPORTER_COLLECTORS
+      value: "/etc/dcgm-exporter/custom-counters.csv"
+  extraVolumeMounts:
+    - name: dcgm-counters-volume
+      mountPath: /etc/dcgm-exporter/custom-counters.csv
+      subPath: custom-counters.csv
+      readOnly: true


### PR DESCRIPTION
Adds some additional configuration to the NVIDIA GPU Operator deployment to support extra DCGM fields, which are use to collect and calculate metrics.

Ticket: [SUSEAI-519](https://jira.suse.com/browse/SUSEAI-519)