### PR TITLE
Add SUSE AI Factory

### DIFF
--- a/docs/AWS_Setup.md
+++ b/docs/AWS_Setup.md
@@ -4,6 +4,7 @@
 - [Prerequisites](#prerequisites)
 - [How Setup The Virtualized Private AI Stack](#setup_howto)
 - [How Cleanup/Destroy The Virtualized Private AI Stack](#setup_howto_cleanup)
+- [Additional Notes: AWS Resources Provisioned](#aws_resources)
 
 # Overview <a name="overview" />
 
@@ -189,12 +190,91 @@ To clean the local environment, run
 
 The above command will delete the Private AI stack, including the VM itself.
 
+# Additional Notes: AWS Resources Provisioned <a name="aws_resources" />
+
+When you run `setup_private_ai_stack.sh`, OpenTofu (Terraform) provisions the
+following AWS resources in your configured `aws_region` (see
+`roles/vm/terraform/*.tf`). Everything is created inside a dedicated VPC and is
+named with your `resource_prefix` (your SUSE username by default), so it is easy
+to identify and clean up. All resources are removed again by
+`destroy_private_ai_stack.sh`.
+
+## Shared networking (created once per deployment)
+
+| AWS resource                | Type                       | Count | Details                                                                                           |
+| --------------------------- | -------------------------- | ----- | ------------------------------------------------------------------------------------------------ |
+| VPC                         | `aws_vpc`                  | 1     | CIDR `10.0.0.0/16`, named `<prefix>-dev-ai-vpc`                                                   |
+| Internet Gateway            | `aws_internet_gateway`     | 1     | `<prefix>-dev-ai-igw`                                                                             |
+| Public subnets              | `aws_subnet`               | 2     | `10.0.0.0/19` in `az1` and `10.0.32.0/19` in `az2`; auto-assign public IP                         |
+| Route table                 | `aws_route_table`          | 1     | Plus 1 default route (`0.0.0.0/0` → IGW) and 2 subnet associations                                |
+| Security group              | `aws_security_group`       | 1     | Inbound rules for SSH, Rancher/RKE2, ingress (80/443) and observability ports; all outbound open  |
+| SSH key pair                | `aws_key_pair`             | 1     | Imports the public key you provide in `extra_vars.yml`                                            |
+
+> **_NOTE:_** By default the instances get **public IPs but no public DNS
+> records** (to reduce cost), which is why you update `/etc/hosts` manually after
+> setup. Setting `enable_external_dns: true` enables automatic DNS record
+> management via [ExternalDNS][external-dns-project]. **Cloudflare is the
+> supported DNS provider** — provide your `cloudflare_api_token` (and related
+> settings) in `extra_vars.yml`, and DNS records are created/updated
+> automatically instead of editing `/etc/hosts`. When using
+> `cloudflare_api_token`, set the DNS domain the records are created under via
+> `external_dns_domain_filter` (defaults to `suseclouddev.com`); this domain is
+> also used to build the generated hostnames (e.g.
+> `rancher-<github_username>-<id>.<external_dns_domain_filter>`).
+
+## Per RKE2 cluster
+
+The **management (mgmt) cluster is always created**. The **SUSE AI cluster** and
+the **SUSE Observability cluster** are only created when you add the optional
+`suse_ai_cluster:` / `suse_observability_cluster:` blocks to `extra_vars.yml`
+(see below). Otherwise those workloads run on the mgmt cluster.
+
+For **each** cluster the following are provisioned:
+
+**EC2 instances** (each with one root EBS volume of `root_volume_size` GB — default 350):
+
+| Node role                   | Controlled by                 | Default | Instance type (default)   | Name pattern (mgmt example)          |
+| --------------------------- | ----------------------------- | ------- | ------------------------- | ------------------------------------ |
+| Control-plane master        | always 1                      | 1       | `instance_type_cp` (`g4dn.2xlarge`) | `<prefix>-dev-mgmt-cp0`              |
+| Additional control-plane    | `num_cp_nodes` − 1            | 0       | `instance_type_cp`        | `<prefix>-dev-mgmt-cp<N>`            |
+| GPU workers                 | `num_worker_nodes_gpu`        | 0       | `instance_type_gpu` (`g4dn.2xlarge`) | `<prefix>-dev-mgmt-worker-gpu-<N>`  |
+| Non-GPU workers             | `num_worker_nodes_nongpu`     | 0       | `instance_type_nongpu` (`m5d.2xlarge`) | `<prefix>-dev-mgmt-worker-nongpu-<N>` |
+
+(The SUSE AI cluster uses the same roles with `-dev-ai-*` names; the Observability
+cluster uses `-dev-observability-*` names and a single `num_worker_nodes` worker
+role.)
+
+**Load balancers** — 2 internet-facing Layer-4 Network Load Balancers (NLBs) per cluster:
+
+| Load balancer   | Type                | Listeners (TCP) | Purpose                                   |
+| --------------- | ------------------- | --------------- | ----------------------------------------- |
+| RKE2 API NLB    | `aws_lb` (network)  | 9345, 6443      | Fixed registration address / Kube API     |
+| Ingress NLB     | `aws_lb` (network)  | 443, 80         | Cluster ingress (Rancher, Open WebUI, …)  |
+
+Each NLB has its own target groups and listeners, with all control-plane and
+worker nodes of that cluster attached as targets.
+
+## Example footprints
+
+- **Default (mgmt cluster only, `num_cp_nodes: 1`, workers `0`)** — the
+  out-of-the-box `extra_vars.yml.aws.example`:
+  - 1 EC2 instance (`g4dn.2xlarge`, GPU) with a 350 GB root volume
+  - 2 NLBs (RKE2 API + Ingress)
+  - 1 VPC, 1 Internet Gateway, 2 subnets, 1 route table, 1 security group, 1 key pair
+- **All three clusters deployed** — the shared networking above (created once) plus,
+  per cluster, its EC2 instances and 2 NLBs (up to **6 NLBs** total).
+
+> **_TIP:_** The exact set of instances scales with the `num_cp_nodes`,
+> `num_worker_nodes_gpu`, `num_worker_nodes_nongpu` (and `num_worker_nodes` for
+> observability) values in each cluster block.
+
+
 [aws]: https://aws.amazon.com/
 [aws-console]: https://aws.amazon.com/console/
+[external-dns-project]: https://github.com/kubernetes-sigs/external-dns
 [llm]: https://en.wikipedia.org/wiki/Large_language_model
 [ollama]: https://ollama.com/
 [open-webui]: https://github.com/open-webui/open-webui
 [rancher-prime]: https://www.rancher.com/products/rancher-platform
 [rke2]: https://www.rancher.com/products/secure-kubernetes-distribution
 [sle-micro]: https://www.suse.com/products/micro/
-

--- a/extra_vars.yml.aws.example
+++ b/extra_vars.yml.aws.example
@@ -24,6 +24,11 @@
 #suse_ai_registration_code: INTERNAL-USE-ONLY-xxxx-xxxx
 
 #
+# NVIDIA credentials
+#
+#nvidia_token: nvapi-xxxxxxxxxxxxxxxxxxxxxxxxxxxx
+
+#
 # Your github username
 #
 github_username: <your github username>
@@ -279,6 +284,17 @@ suse_observability_license: <your SUSE Observability license>
 # Install openwebui pipelines
 #
 pipelines_enabled: true
+
+#
+# SUSE AI Factory - Deployed to the main/mgmt cluster
+#
+suse_ai_factory:
+  enabled: true
+  # version: defaults to the latest aif-operator chart published to
+  # oci://ghcr.io/suse/chart/aif-operator. Uncomment to pin a specific version.
+  # version: 2.0.0
+  ai_extension:
+    enabled: true
 
 #
 # RKE2 Management cluster

--- a/extra_vars.yml.local.example
+++ b/extra_vars.yml.local.example
@@ -24,6 +24,11 @@
 #suse_ai_registration_code: INTERNAL-USE-ONLY-xxxx-xxxx
 
 #
+# NVIDIA credentials
+#
+#nvidia_token: nvapi-xxxxxxxxxxxxxxxxxxxxxxxxxxxx
+
+#
 # Your github username
 #
 github_username: <your github username>
@@ -257,3 +262,14 @@ suse_observability_license: <your SUSE Observability license>
 # Install openwebui pipelines
 #
 pipelines_enabled: true
+
+#
+# SUSE AI Factory - Deployed to the main/mgmt cluster
+#
+suse_ai_factory:
+  enabled: true
+  # version: defaults to the latest aif-operator chart published to
+  # oci://ghcr.io/suse/chart/aif-operator. Uncomment to pin a specific version.
+  # version: 2.0.0
+  ai_extension:
+    enabled: true

--- a/playbooks/define_nodes_mgmt_cluster.yml
+++ b/playbooks/define_nodes_mgmt_cluster.yml
@@ -83,6 +83,34 @@
       mgmt_pyyaml_package_name: 'python311-PyYAML'
     when: cluster is not defined
 
+  # Resolve the SUSE AI Factory (aif-operator) chart version.
+  # Precedence: suse_ai_factory.version from extra_vars (explicit override)
+  # otherwise the latest stable chart version published to the OCI registry.
+  - name: Use SUSE AI Factory chart version from extra_vars (override)
+    set_fact:
+      suse_ai_factory_version: "{{ suse_ai_factory.version }}"
+    when:
+      - suse_ai_factory is defined
+      - suse_ai_factory.version is defined
+
+  - name: Fetch latest SUSE AI Factory (aif-operator) chart version
+    ansible.builtin.command:
+      cmd: "helm show chart {{ suse_ai_factory_chart_repo | default('oci://ghcr.io/suse/chart/aif-operator') }}"
+    register: aif_chart_info
+    changed_when: false
+    when:
+      - suse_ai_factory is defined
+      - suse_ai_factory.enabled | default(false)
+      - suse_ai_factory.version is not defined
+
+  - name: Set latest SUSE AI Factory chart version as default
+    set_fact:
+      suse_ai_factory_version: "{{ (aif_chart_info.stdout_lines | select('match', '^version:') | first).split(':')[1] | trim }}"
+    when:
+      - suse_ai_factory is defined
+      - suse_ai_factory.version is not defined
+      - aif_chart_info.stdout_lines is defined
+
 
   - name: Build mgmt extra_vars content
     set_fact:
@@ -129,7 +157,38 @@
             "curl", "git", "pciutils"]
         }}
 
+        suse_ai_factory:
+          enabled: {{ suse_ai_factory.enabled | default(false) }}
+          version: {{ suse_ai_factory_version | default('2.0.0') }}
+
+          ai_extension:
+            enabled: {{ suse_ai_factory.ai_extension.enabled | default(false) }}
+
+        {% if (application_collection_user_token | default("") | length > 0) or (nvidia_token | default("") | length > 0) or (suse_ai_registration_code | default("") | length > 0) %}
+          credentials:
+        {% if application_collection_user_token | default("") | length > 0 %}
+            # credential for oci://dp.apps.rancher.io/charts
+            applicationCollection:
+              username: {{ application_collection_user_email | default("") }}
+              password: {{ application_collection_user_token }}
+        {% endif %}
+        {% if nvidia_token | default("") | length > 0 %}
+            # credential to pull NGC artifacts
+            # e.g. https://helm.ngc.nvidia.com/nvidia
+            nvidia:
+              username: {{ nvidia_user | default('$oauthtoken') }}
+              password: {{ nvidia_token }}
+        {% endif %}
+        {% if suse_ai_registration_code | default("") | length > 0 %}
+            # credential for oci://registry.suse.com/ai/charts
+            suseRegistry:
+              username: {{ suse_ai_registry_user | default('regcode') }}
+              password: {{ suse_ai_registration_code }}
+        {% endif %}
+        {% endif %}
+
   - name: Save mgmt_extra_vars.yml
     copy:
       dest: "../mgmt_extra_vars.yml"
       content: "{{ mgmt_extra_vars_content }}"
+

--- a/playbooks/destroy_private_ai_stack.yml
+++ b/playbooks/destroy_private_ai_stack.yml
@@ -21,27 +21,47 @@
         msg: "{{ tofu_outputs }}"
       when: cloud_provider | default('local') != "local"
 
+    # For local deployments the facts come from static defaults, so resources are
+    # always treated as present. For cloud deployments, empty tofu outputs mean the
+    # resources have already been destroyed - skip fact extraction / node setup and
+    # go straight to the (idempotent) destroy step below.
+    - name: Determine whether cloud resources still exist
+      set_fact:
+        cloud_resources_present: "{{ cloud_provider | default('local') == 'local' or ((tofu_outputs | default({})) | length > 0) }}"
+
+    - name: Report that resources are already destroyed
+      debug:
+        msg: "No tofu outputs found - the cloud resources appear to be already destroyed. Skipping resource fact extraction and node setup."
+      when: not cloud_resources_present
+
     - name: Extract mgmt cluster tofu output
       include_role:
         name: vm
         tasks_from: mgmt_cluster_output
+      when: cloud_resources_present
 
     - name: Extract suse-ai cluster tofu output
       include_role:
         name: vm
         tasks_from: suse_ai_cluster_output
-      when: suse_ai_cluster is defined
+      when:
+        - cloud_resources_present
+        - suse_ai_cluster is defined
 
     - name: Extract suse-observability cluster tofu output
       include_role:
         name: vm
         tasks_from: suse_observability_cluster_output
-      when: suse_observability_cluster is defined and enable_suse_observability | default('False') | bool
+      when:
+        - cloud_resources_present
+        - suse_observability_cluster is defined
+        - enable_suse_observability | default('False') | bool
 
     - name: Include ingress_ouput
       include_role:
         name: vm
         tasks_from: ingress_output.yml
+      when: cloud_resources_present
 
 - name: Setup the right python interpreter based on the distro
   import_playbook: setup_python_interpreter.yml
@@ -50,18 +70,24 @@
   import_playbook: define_nodes_mgmt_cluster.yml
   vars:
     python_interpreter: "{{ hostvars['localhost']['python_interpreter'] }}"
+  when: hostvars['localhost']['cloud_resources_present'] | bool
 
 - name: Define suse ai cluster nodes
   import_playbook: define_nodes_suse_ai_cluster.yml
   vars:
     suse_ai_python_interpreter: "{{ hostvars['localhost']['suse_ai_python_interpreter'] }}"
-  when: suse_ai_cluster is defined
+  when:
+    - hostvars['localhost']['cloud_resources_present'] | bool
+    - suse_ai_cluster is defined
 
 - name: Define suse observability cluster nodes
   import_playbook: define_nodes_suse_observability_cluster.yml
   vars:
     suse_observability_python_interpreter: "{{ hostvars['localhost']['suse_observability_python_interpreter'] }}"
-  when: suse_observability_cluster is defined and enable_suse_observability | default('False') | bool
+  when:
+    - hostvars['localhost']['cloud_resources_present'] | bool
+    - suse_observability_cluster is defined
+    - enable_suse_observability | default('False') | bool
 
 - hosts: mgmt_master:suse_ai_master:suse_observability_master
   gather_facts: false

--- a/playbooks/display.yml
+++ b/playbooks/display.yml
@@ -16,19 +16,52 @@
       register: suse_observability_admin_password_file_contents
       when: enable_suse_observability | default(false)
 
+    - name: Prepare /etc/hosts entries (short hostnames)
+      set_fact:
+        hosts_entries: "{{ hosts_entries | default([]) + [ item.entry ] }}"
+      when: item.eval
+      with_items:
+        - entry: "{{ vm_ip }} mgmt-rancher"
+          eval: true
+        - entry: "{{ hostvars['localhost']['suse_ai_vm_ip'] | default(hostvars['localhost']['vm_ip'])}} suse-ai"
+          eval: true
+        - entry: "{{ vm_ip }} longhorn"
+          eval: "{{ enable_longhorn | default(False) | bool }}"
+        - entry: "{{ hostvars['localhost']['suse_observability_vm_ip'] | default(hostvars['localhost']['vm_ip'])}} suse-observability"
+          eval: "{{ enable_suse_observability | default(False) | bool }}"
+
+    - name: Prepare URL entries (FQDNs)
+      set_fact:
+        url_entries: "{{ url_entries | default([]) + [ item.entry ] }}"
+      when: item.eval
+      with_items:
+        - entry: "{{ vm_ip }} {{ rancher_host }}"
+          eval: "{{ not (enable_external_dns | default(False)) }}"
+        - entry: "{{ hostvars['localhost']['suse_ai_vm_ip'] | default(hostvars['localhost']['vm_ip'])}} {{ open_webui_host }}"
+          eval: "{{ not (enable_external_dns | default(False)) }}"
+        - entry: "{{ vm_ip }} {{ longhorn_host }}"
+          eval: "{{ not (enable_external_dns | default(False)) and (enable_longhorn | default(False) | bool) }}"
+        - entry: "{{ hostvars['localhost']['suse_observability_vm_ip'] | default(hostvars['localhost']['vm_ip'])}} {{ suse_observability_host }}"
+          eval: "{{ not (enable_external_dns | default(False)) and (enable_suse_observability | default(False) | bool) }}"
+
+    - name: Display /etc/hosts entries
+      debug:
+        msg: 
+        - "Add these items to /etc/hosts as line entries:"
+        - "{{ (hosts_entries | default([]) + url_entries | default([])) | join(', ') }}"
+      when: (hosts_entries is defined and hosts_entries | length > 0) or (url_entries is defined and url_entries | length > 0)
+
+    - name: Write host entries to suse_ai_stack_host_entries
+      copy:
+        dest: "/tmp/suse_ai_stack_host_entries"
+        content: "{{ (hosts_entries | default([]) + url_entries | default([])) | join('\n') }}\n"
+      when: (hosts_entries is defined and hosts_entries | length > 0) or (url_entries is defined and url_entries | length > 0)
+
     - name: Set Access URL and credentials
       set_fact:
         access_msg: "{{ access_msg | default([]) + [ item.msg | string ] }}"
       when: item.eval
       with_items:
-        - msg: "Make sure to update the /etc/hosts file: {{ vm_ip }} mgmt-rancher {{ rancher_host }}"
-          eval: "{{ not (enable_external_dns | default(False)) }}"
-        - msg: "Make sure to update the /etc/hosts file: {{ hostvars['localhost']['suse_ai_vm_ip'] | default(hostvars['localhost']['vm_ip'])}} suse-ai {{ open_webui_host }}"
-          eval: "{{ not (enable_external_dns | default(False)) }}"
-        - msg: "Make sure to update the /etc/hosts file: {{ vm_ip }} {{ longhorn_host }}"
-          eval: "{{ not (enable_external_dns | default(False)) and (enable_longhorn | default(False) | bool) }}"
-        - msg: "Make sure to update the /etc/hosts file: {{ hostvars['localhost']['suse_observability_vm_ip'] | default(hostvars['localhost']['vm_ip'])}} {{ suse_observability_host }}"
-          eval: "{{ not (enable_external_dns | default(False)) and (enable_suse_observability | default(False) | bool) }}"
         - msg: "To access rancher UI, point your browser to https://{{ rancher_host }} and login with user=admin and password={{ rancher_bootstrap_password | default('rancher')  }}"
           eval: true
         - msg: "To access longhorn UI, point your browser to http://{{ longhorn_host }} and login with user={{ longhorn_username | default('admin')}} and password={{  longhorn_password | default('longhorn')}}"
@@ -44,5 +77,12 @@
 
     - name: Output access msg to a file
       copy:
-        dest: "/tmp/access"
+        dest: "/tmp/suse_ai_stack_access"
         content: "{{ access_msg }}"
+
+    - name: Display note
+      debug:
+        msg:
+          - "Note: the terminal output shown above is no longer accessible once exited,"
+          - "but the same information is saved in /tmp/suse_ai_stack_host_entries and"
+          - "/tmp/suse_ai_stack_access for later reference."

--- a/roles/suse-private-ai/defaults/main.yml
+++ b/roles/suse-private-ai/defaults/main.yml
@@ -42,6 +42,15 @@ opensearch_release_name: opensearch
 opensearch_cluster_deployment: false
 opensearch_admin_password: "MySecurePass123"
 
+# flag to enable deployment of ollama
+enable_ollama: true
+
+# flag to enable deployment of open-webui
+enable_open_webui: true
+
+# flag to enable deployment of open-webui-mcpo
+enable_open_webui_mcpo: true
+
 #Flag to indicate whether ollama should be installed seperately or part of the open-webui
 ollama_deploy_separately: true
 

--- a/roles/suse-private-ai/tasks/main.yml
+++ b/roles/suse-private-ai/tasks/main.yml
@@ -17,6 +17,7 @@
 
 - name: ollama deploy
   include_tasks: ollama.yml
+  when: enable_ollama | default(true)
 
 - name: vllm deploy
   include_tasks: vllm.yml
@@ -24,7 +25,9 @@
 
 - name: open-webui-mcpo deploy
   include_tasks: open-webui-mcpo.yml
+  when: enable_open_webui_mcpo | default(true)
 
 - name: open-webui deploy
   include_tasks: open-webui.yml
+  when: enable_open_webui | default(true)
 

--- a/setup_private_ai_stack.sh
+++ b/setup_private_ai_stack.sh
@@ -11,6 +11,15 @@ if [ ! -d ${LIBVIRT_IMAGES_DIR} ] ; then
   LIBVIRT_IMAGES_DIR=${PROJECT_DIR}/libvirt_images
 fi
 
+# Print the full ansible-playbook command (copy-pasteable), then run it.
+# When DEBUG is set, the command is only printed and not executed.
+run_ansible_playbook() {
+  printf '+ ansible-playbook'
+  printf ' %q' "$@"
+  printf '\n'
+  ${DEBUG:+echo} ansible-playbook "$@"
+}
+
 setup_name=$(basename ${BASH_SOURCE[0]} .sh)
 setup_type=${setup_name#setup_}
 playbook=${setup_name}
@@ -23,15 +32,23 @@ case "${setup_type}" in
 	;;
 esac
 
-# Base argument
-base_playbook_args=(
-  -e current_project_dir="${PROJECT_DIR}"
-  -e libvirt_images_dir="${LIBVIRT_IMAGES_DIR}"
-)
-
 if [ ! -f "${EXTRA_VARS_FILE}" ] ; then
 	echo "ERROR: ${EXTRA_VARS_FILE} not found. Did you remember to copy extra_vars.yml.example to extra_vars.yml and configure it appropriately?"
 	exit 1
+fi
+
+# Determine cloud_provider from extra_vars.yml (defaults to "local" when unset)
+cloud_provider=$(grep -E '^[[:space:]]*cloud_provider[[:space:]]*:' "${EXTRA_VARS_FILE}" | tail -1 | sed -E 's/^[[:space:]]*cloud_provider[[:space:]]*:[[:space:]]*//; s/#.*//; s/["'\'' ]//g')
+cloud_provider=${cloud_provider:-local}
+
+# Base argument
+base_playbook_args=(
+  -e current_project_dir="${PROJECT_DIR}"
+)
+
+# libvirt_images_dir is only relevant for local (libvirt) deployments
+if [ "${cloud_provider}" = "local" ]; then
+  base_playbook_args+=( -e libvirt_images_dir="${LIBVIRT_IMAGES_DIR}" )
 fi
 
 if ! command -v ansible-playbook &> /dev/null; then
@@ -72,7 +89,7 @@ playbook_args+=(
   "$@"
 )
 
-${DEBUG:+echo} ansible-playbook "${playbook_args[@]}"
+run_ansible_playbook "${playbook_args[@]}"
 
 ### CLONE suse-ai-node-ansible repo as external_playbooks
 EXT_REPO_URL="https://github.com/SUSE/suse-ai-node-ansible.git"
@@ -119,7 +136,7 @@ for cluster in "${clusters[@]}"; do
 
   # Run through each cluster - mgmt, suse-ai, suse-observability with own ini files
   if [ -e "${PROJECT_DIR}/inventories/${cluster}_inventory.ini" ]; then
-    ${DEBUG:+echo} ansible-playbook "${playbook_args[@]}"
+    run_ansible_playbook "${playbook_args[@]}"
   fi
 
 done
@@ -140,7 +157,7 @@ playbook_args=(
   "$PROJECT_DIR/playbooks/${playbook}.yml"
 )
 
-${DEBUG:+echo} ansible-playbook "${playbook_args[@]}"
+run_ansible_playbook "${playbook_args[@]}"
 
 
 # DEPLOY external-dns, storage on all clusters
@@ -158,7 +175,7 @@ for cluster in "${clusters[@]}"; do
 
   # Run through each cluster - mgmt, suse-ai, suse-observability with own ini files
   if [ -e "${PROJECT_DIR}/inventories/${cluster}_inventory.ini" ]; then
-    ${DEBUG:+echo} ansible-playbook "${playbook_args[@]}"
+    run_ansible_playbook "${playbook_args[@]}"
   fi
 
 done
@@ -179,7 +196,7 @@ playbook_args=(
   "$PROJECT_DIR/playbooks/${playbook}.yml"
 )
 
-${DEBUG:+echo} ansible-playbook "${playbook_args[@]}"
+run_ansible_playbook "${playbook_args[@]}"
 
 ### Deploy SUSE AI
 playbook="deploy_suse_ai" # playbook that deploys suse ai
@@ -196,7 +213,7 @@ playbook_args=(
   "$PROJECT_DIR/playbooks/${playbook}.yml"
 )
 
-${DEBUG:+echo} ansible-playbook "${playbook_args[@]}"
+run_ansible_playbook "${playbook_args[@]}"
 
 ### Display access info
 playbook="display" # playbook that displays access info
@@ -208,4 +225,4 @@ playbook_args=(
   "$PROJECT_DIR/playbooks/${playbook}.yml"
 )
 
-${DEBUG:+echo} ansible-playbook "${playbook_args[@]}"
+run_ansible_playbook "${playbook_args[@]}"


### PR DESCRIPTION
  Deploy SUSE AI Factory

  Set the SUSE AI Factory (aif-operator) chart version to the latest
  published chart by default, overridable via suse_ai_factory.version
  in extra_vars.

  In addition:
  Changes to display all /etc/hosts entries and save them in files
  for later reference.

  Support to enable/disable ollama, open-webui and mcpo.

  Improve destroy script to make idempotent.

  Add additional documentation about AWS resources created.

  Improve setup_private_ai_stack.sh to show the ansible-playbook commands
  being run, and only pass libvirt_images_dir for local (libvirt)
  deployments.