### PR TITLE
Harden SUSE AI Factory chart version resolution

### DIFF
--- a/docs/AWS_Setup.md
+++ b/docs/AWS_Setup.md
@@ -32,6 +32,11 @@ The instructions on this document are for setting it on [AWS][aws].
   ansible-galaxy collection install -r requirements.yml
   ```
 * opentofu: https://opentofu.org/docs/intro/install/
+* helm: https://helm.sh/docs/intro/install/ — required on the ansible controller node to
+  resolve the latest SUSE AI Factory (`aif-operator`) chart version when SUSE AI
+  Factory is enabled. If `helm` is missing (or the registry is unreachable) and
+  no version is pinned, the deployment fails with a clear error. To avoid the
+  lookup entirely, pin `suse_ai_factory.version` in `extra_vars.yml`.
 
 # How Setup The Virtualized Private AI Stack <a name="setup_howto">
 

--- a/docs/Local_Setup.md
+++ b/docs/Local_Setup.md
@@ -38,6 +38,13 @@ environment using [libvirt][libvirt].
   ```console
   ansible-galaxy collection install -r requirements.yml
   ```
+
+* helm: https://helm.sh/docs/intro/install/ — required on the ansible controller node to
+  resolve the latest SUSE AI Factory (`aif-operator`) chart version when SUSE AI
+  Factory is enabled. If `helm` is missing (or the registry is unreachable) and
+  no version is pinned, the deployment fails with a clear error. To avoid the
+  lookup entirely, pin `suse_ai_factory.version` in `extra_vars.yml`.
+
 ## Create Virtual Network <a name="create_virtual_network" />
 
 By default, the libvirt `default` virtual network is used. Therefore, you must

--- a/playbooks/define_nodes_mgmt_cluster.yml
+++ b/playbooks/define_nodes_mgmt_cluster.yml
@@ -84,8 +84,12 @@
     when: cluster is not defined
 
   # Resolve the SUSE AI Factory (aif-operator) chart version.
-  # Precedence: suse_ai_factory.version from extra_vars (explicit override)
+  # Precedence: suse_ai_factory.version from extra_vars (explicit override),
   # otherwise the latest stable chart version published to the OCI registry.
+  # The registry lookup requires 'helm' on the ansible controller node. When SUSE AI
+  # Factory is enabled and no version is pinned, an unresolved version is a hard
+  # error (see the assert below) rather than a silent fallback. The lookup is
+  # skipped during destroy (aif_skip_version_resolution), where it is not needed.
   - name: Use SUSE AI Factory chart version from extra_vars (override)
     set_fact:
       suse_ai_factory_version: "{{ suse_ai_factory.version }}"
@@ -98,18 +102,38 @@
       cmd: "helm show chart {{ suse_ai_factory_chart_repo | default('oci://ghcr.io/suse/chart/aif-operator') }}"
     register: aif_chart_info
     changed_when: false
+    failed_when: false
     when:
+      - not (aif_skip_version_resolution | default(false))
       - suse_ai_factory is defined
       - suse_ai_factory.enabled | default(false)
       - suse_ai_factory.version is not defined
 
   - name: Set latest SUSE AI Factory chart version as default
     set_fact:
-      suse_ai_factory_version: "{{ (aif_chart_info.stdout_lines | select('match', '^version:') | first).split(':')[1] | trim }}"
+      suse_ai_factory_version: "{{ (_aif_version_lines | first).split(':')[1] | trim }}"
+    vars:
+      _aif_version_lines: "{{ (aif_chart_info.stdout_lines | default([])) | select('match', '^version:') | list }}"
     when:
       - suse_ai_factory is defined
       - suse_ai_factory.version is not defined
-      - aif_chart_info.stdout_lines is defined
+      - (aif_chart_info.rc | default(1)) == 0
+      - _aif_version_lines | length > 0
+
+  - name: Ensure SUSE AI Factory chart version was resolved
+    assert:
+      that:
+        - suse_ai_factory_version is defined
+      fail_msg: >-
+        Could not resolve the latest aif-operator chart version. Ensure 'helm'
+        is installed on the ansible controller node and the registry
+        ({{ suse_ai_factory_chart_repo | default('oci://ghcr.io/suse/chart/aif-operator') }})
+        is reachable, or pin suse_ai_factory.version in extra_vars.yml.
+    when:
+      - not (aif_skip_version_resolution | default(false))
+      - suse_ai_factory is defined
+      - suse_ai_factory.enabled | default(false)
+      - suse_ai_factory.version is not defined
 
 
   - name: Build mgmt extra_vars content
@@ -191,4 +215,3 @@
     copy:
       dest: "../mgmt_extra_vars.yml"
       content: "{{ mgmt_extra_vars_content }}"
-

--- a/playbooks/destroy_private_ai_stack.yml
+++ b/playbooks/destroy_private_ai_stack.yml
@@ -70,6 +70,8 @@
   import_playbook: define_nodes_mgmt_cluster.yml
   vars:
     python_interpreter: "{{ hostvars['localhost']['python_interpreter'] }}"
+    # Teardown does not need the aif-operator chart version; skip the helm lookup.
+    aif_skip_version_resolution: true
   when: hostvars['localhost']['cloud_resources_present'] | bool
 
 - name: Define suse ai cluster nodes

--- a/playbooks/display.yml
+++ b/playbooks/display.yml
@@ -46,7 +46,7 @@
 
     - name: Display /etc/hosts entries
       debug:
-        msg: 
+        msg:
         - "Add these items to /etc/hosts as line entries:"
         - "{{ (hosts_entries | default([]) + url_entries | default([])) | join(', ') }}"
       when: (hosts_entries is defined and hosts_entries | length > 0) or (url_entries is defined and url_entries | length > 0)

--- a/roles/suse-private-ai/templates/open-webui-values.yaml.j2
+++ b/roles/suse-private-ai/templates/open-webui-values.yaml.j2
@@ -13,7 +13,7 @@ image:
   tag:  {{ openwebui_image_version }}
   pullPolicy: "IfNotPresent"
 {% endif %}
-{% if ollama_deploy_separately %}
+{% if enable_ollama | default(true) and ollama_deploy_separately %}
 ollamaUrls:
 - http://ollama.{{suse_private_ai_namespace}}.svc.cluster.local:11434
 {% endif %}
@@ -21,7 +21,7 @@ persistence:
   enabled: true
   size: 10Gi
   storageClass: {{ storage_class }}
-{% if ollama_deploy_separately %}
+{% if ollama_deploy_separately or not (enable_ollama | default(true)) %}
 ollama:
   enabled: false
 {% else %}


### PR DESCRIPTION
  - Fail fast with a clear assert when aif-operator version can't be resolved (helm missing/registry unreachable) and no version is pinned, instead of aborting on a raw helm error
  - Skip the helm version lookup during destroy (aif_skip_version_resolution)
  - Make version parsing defensive (no error on empty/changed helm output)
  - Honor enable_ollama in the embedded open-webui case so it fully disables Ollama regardless of ollama_deploy_separately
  - Document helm as a prerequisite on the ansible controller node
  - Fix trailing whitespace and missing EOF newlines